### PR TITLE
fix build on avr-rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
 //! The information for each device is separated into submodules, named after
 //! the microcontroller itself.
 
+#![no_std]
+
 pub use self::gen::*;
 
 mod gen;


### PR DESCRIPTION
This fails to build with `avr-rust` because it tries to pull in `std`.