### PR TITLE
Optimize debug builds by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ all_mcus = []
 
 [build-dependencies]
 avr-mcu = "0.2"
+
+[profile.dev]
+# Most of the build consists of generating the mcu description files. So
+# enable optimizations to speed this process.
+opt-level = 2


### PR DESCRIPTION
During the build of this crate, the main bottleneck is the
generation of the mcu description files. The compilation itself
takes far less time. Therefore, optimizing the build will lead to
faster builds.