### PR TITLE
Speed up Travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: rust
 rust:
   - nightly
 
+script:
+  - cargo test --verbose --release


### PR DESCRIPTION
This speed ups test passing because by default Travis build is debug, and it's VERY slow